### PR TITLE
fix: fixed compile bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,27 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts_aliyun
-PKG_VERSION:=1.0.0
+PKG_VERSION:=1.0.3
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPLv2
 PKG_MAINTAINER:=Sense <sensec@gmail.com>
 
+PKG_BUILD_PARALLEL:=1
+
 include $(INCLUDE_DIR)/package.mk
 
-define Package/$(PKG_NAME)
-	SECTION:=net
-	CATEGORY:=Network
-	SUBMENU:=IP Addresses and Names
-	TITLE:=DDNS extension for AliYun.com
-	PKGARCH:=all
-	DEPENDS:=+ddns-scripts +wget +openssl-util
+define Package/ddns-scripts_aliyun
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=IP Addresses and Names
+  TITLE:=DDNS extension for AliYun.com
+  PKGARCH:=all
+  DEPENDS:=+ddns-scripts +wget-ssl +openssl-util
 endef
 
-define Package/$(PKG_NAME)/description
-	Dynamic DNS Client scripts extension for AliYun.com
+define Package/ddns-scripts_aliyun/description
+  Dynamic DNS Client scripts extension for AliYun.com
 endef
 
 define Build/Configure
@@ -29,21 +31,19 @@ define Build/Compile
 	$(CP) ./*.{sh,json} $(PKG_BUILD_DIR)
 endef
 
-define Package/$(PKG_NAME)/preinst
+define Package/ddns-scripts_aliyun/preinst
 	#!/bin/sh
 	# if NOT run buildroot then stop service
 	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
 	exit 0 # suppress errors
 endef
 
-define Package/$(PKG_NAME)/install
+define Package/ddns-scripts_aliyun/install
 	$(INSTALL_DIR) $(1)/usr/lib/ddns
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/update_aliyun_com.sh $(1)/usr/lib/ddns
-	$(INSTALL_DIR) $(1)/usr/share/ddns/default
-        $(INSTALL_BIN) $(PKG_BUILD_DIR)/aliyun.com.json $(1)/usr/share/ddns/default
 endef
 
-define Package/$(PKG_NAME)/postinst
+define Package/ddns-scripts_aliyun/postinst
 	#!/bin/sh
 	# remove old services file entries
 	/bin/sed -i '/aliyun\.com/d' $${IPKG_INSTROOT}/etc/ddns/services >/dev/null 2>&1
@@ -59,7 +59,7 @@ define Package/$(PKG_NAME)/postinst
 	exit 0 # suppress errors
 endef
 
-define Package/$(PKG_NAME)/prerm
+define Package/ddns-scripts_aliyun/prerm
 	#!/bin/sh
 	# if NOT run buildroot then stop service
 	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
@@ -69,4 +69,4 @@ define Package/$(PKG_NAME)/prerm
 	exit 0 # suppress errors
 endef
 
-$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,ddns-scripts_aliyun))


### PR DESCRIPTION
on openwrt brach v22.03.0, output "Makefile:72: *** missing separator (did you mean TAB instead of 8 spaces?). Stop." when compiling